### PR TITLE
Add Basic CI-CD pipeline

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,35 @@
+name: Build and Run tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8.5
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8.5
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The Github editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest and generate report
+        run: |
+          coverage run --source=noise_sensors_monitoring,mqtt -m pytest
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Noise Sensor Monitoring
+![Project Build](https://github.com/SunbirdAI/noise-sensors-monitoring/actions/workflows/python-app.yml/badge.svg)
+[![codecov](https://codecov.io/gh/SunbirdAI/noise-sensors-monitoring/branch/main/graph/badge.svg?token=YOI8JHFD0S)](https://codecov.io/gh/SunbirdAI/noise-sensors-monitoring)
 This repository contains code for the noise sensor monitoring project.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "*/tests/*"


### PR DESCRIPTION
This PR adds:
- A GitHub actions workflow that includes running the tests and uploading code coverage to codecov
- Badges to indicate build status and coverage metrics