### PR TITLE
Add validation for creating and editing a device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ venv/
 __pycache__
 .coverage
 .idea
+.vscode
 .env
 data
 try_broker_publish.py

--- a/devices/forms.py
+++ b/devices/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm
+from django.forms import ModelForm, ValidationError
 from .models import Device
 
 
@@ -6,3 +6,10 @@ class DeviceForm(ModelForm):
     class Meta:
         model = Device
         exclude = ['id']
+
+    def clean_imei(self, *args, **kwargs):
+        imei = self.cleaned_data.get('imei')
+        if len(imei) != 15:
+            raise ValidationError('IMEI must be 15-digit number')
+        return imei
+

--- a/devices/forms.py
+++ b/devices/forms.py
@@ -1,5 +1,6 @@
 from django.forms import ModelForm, ValidationError
 from .models import Device
+import re
 
 
 class DeviceForm(ModelForm):
@@ -13,3 +14,10 @@ class DeviceForm(ModelForm):
             raise ValidationError('IMEI must be 15-digit number')
         return imei
 
+    def clean_phone_number(self, *args, **kwargs):
+        # this particular validation is a placeholder and should be updated later
+        phone_number = self.cleaned_data.get('phone_number')
+        pattern = '^(07)([0-9]{8})$'
+        if not re.match(pattern, phone_number):
+            raise ValidationError('Please enter a valid phone number')
+        return phone_number

--- a/devices/tests.py
+++ b/devices/tests.py
@@ -38,7 +38,32 @@ class DeviceTests(TestCase):
     def test_device_edit_view(self):
         response = self.client.post(
             reverse('edit_device', kwargs={'pk': self.device.id}),
-            {'device_name': 'First sensor - edited'}
+            {
+                'device_name': 'First sensor - edited',
+                'imei': '123456789012345',
+                'phone_number': '0771234567'
+            }
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'First sensor - edited')
+
+    def test_device_edit_view_short_phone_no(self):
+        response = self.client.post(
+            reverse('edit_device', kwargs={'pk': self.device.id}),
+            {'phone_number': '077123456'}
+        )
+        self.assertContains(response, 'Please enter a valid phone number')
+
+    def test_device_edit_view_wrong_phone_no(self):
+        response = self.client.post(
+            reverse('edit_device', kwargs={'pk': self.device.id}),
+            {'phone_number': '0990123456'}
+        )
+        self.assertContains(response, 'Please enter a valid phone number')
+
+    def test_device_edit_view_invalid_imei(self):
+        response = self.client.post(
+            reverse('edit_device', kwargs={'pk': self.device.id}),
+            {'imei': '1234567890'}
+        )
+        self.assertContains(response, 'IMEI must be 15-digit number')


### PR DESCRIPTION
This PR adds validation for creating and editing a device. Descriptive messages are shown when invalid info is input.

List of validations:
- Make sure IMEI is a 15-digit number
- Make sure the phone number is valid
- ~~Make sure the version number is in the correct format~~ Not done because this field is missing from the 'Device' model at the time of this PR