### PR TITLE
Add new MQTT Fields for the "logs" topic

### DIFF
--- a/devices/models.py
+++ b/devices/models.py
@@ -61,7 +61,7 @@ class Device(models.Model):
 
     @property
     def get_recordings(self):
-        return self.recording_set.order_by('time_uploaded')[:10:-1]
+        return self.recording_set.order_by('-time_recorded')[:10]
 
     def get_absolute_url(self):
         return reverse('device_detail', args=[str(self.id)])

--- a/heroku.yml
+++ b/heroku.yml
@@ -9,4 +9,4 @@ release:
   command:
     - python manage.py collectstatic --noinput
 run:
-  web: gunicorn noise_dashboard.wsgi --timeout 300
+  web: gunicorn noise_dashboard.wsgi --workers=8 --threads=2 --timeout 300

--- a/noise_sensors_monitoring/domain/sensor.py
+++ b/noise_sensors_monitoring/domain/sensor.py
@@ -8,7 +8,10 @@ class Sensor:
     connected: bool
     longitude: float
     latitude: float
-    batteryLevel: float
+    bV: float
+    pV: float
+    LastRec: float
+    LastUpl: float
     sigStrength: float
     DataBalance: float
 

--- a/noise_sensors_monitoring/requests/sensor_reading.py
+++ b/noise_sensors_monitoring/requests/sensor_reading.py
@@ -2,15 +2,18 @@ from typing import Optional, Dict
 
 from noise_sensors_monitoring.requests.generic_requests import Request, InvalidRequest, ValidRequest
 
-REQUIRED_FIELDS = ["deviceId", "dbLevel", "connected", "batteryLevel", "sigStrength", "DataBalance"]
-OPTIONAL_FIELDS = ["latitude", "longitude"]
+REQUIRED_FIELDS = ["deviceId", "dbLevel", "LastRec", "LastUpl", "pV", "bV", "sigStrength", "DataBalance"]
+OPTIONAL_FIELDS = ["latitude", "longitude", "connected"]
 REQUIRED_TYPES = {
     "deviceId": str,
     "dbLevel": float,
     "connected": bool,
     "longitude": float,
     "latitude": float,
-    "batteryLevel": float,
+    "LastRec": float,
+    "LastUpl": float,
+    "pV": float,
+    "bV": float,
     "sigStrength": float,
     "DataBalance": float
 }

--- a/tests/domain/test_sensor.py
+++ b/tests/domain/test_sensor.py
@@ -8,17 +8,20 @@ def test_sensor_model_init():
         connected=True,
         longitude=1.034,
         latitude=0.564,
-        batteryLevel=30,
+        pV=30,
+        bV=30,
+        LastRec=3,
+        LastUpl=2,
         sigStrength=26,
         DataBalance=56.0
     )
 
     assert sensor.deviceId == "SB1001"
     assert sensor.dbLevel == 76
-    assert sensor.connected == True
+    assert sensor.connected is True
     assert sensor.longitude == 1.034
     assert sensor.latitude == 0.564
-    assert sensor.batteryLevel == 30
+    assert sensor.bV == 30
     assert sensor.sigStrength == 26
 
 
@@ -29,7 +32,10 @@ def test_from_dict_init():
         "connected": True,
         "longitude": 1.034,
         "latitude": 0.564,
-        "batteryLevel": 30,
+        "bV": 30,
+        "pV": 30,
+        "LastRec": 3,
+        "LastUpl": 2,
         "sigStrength": 26,
         "DataBalance": 56.0,
     }
@@ -41,5 +47,5 @@ def test_from_dict_init():
     assert sensor.connected
     assert sensor.longitude == 1.034
     assert sensor.latitude == 0.564
-    assert sensor.batteryLevel == 30
+    assert sensor.bV == 30
     assert sensor.sigStrength == 26

--- a/tests/requests/test_sensor_reading.py
+++ b/tests/requests/test_sensor_reading.py
@@ -18,7 +18,7 @@ def test_build_request_without_all_fields():
 
     assert bool(request) is False
     assert request.has_errors()
-    assert len(request.errors) == 4
+    assert len(request.errors) == 6
     assert request.errors[0]["type"] == "Missing values"
 
 
@@ -29,7 +29,10 @@ def test_build_request_with_invalid_fields():
         "connected": True,
         "longitude": 1.034,
         "latitude": 0.564,
-        "batteryLevel": 30,
+        "bV": 30,
+        "pV": 30,
+        "LastRec": 3,
+        "LastUpl": 2,
         "sigStrength": 26,
         "randomField": 26,
         "DataBalance": 67.0
@@ -48,7 +51,10 @@ def test_build_request_with_invalid_types():
         "connected": 78,
         "longitude": 1.034,
         "latitude": 0.564,
-        "batteryLevel": 30.9,
+        "bV": 30,
+        "pV": 30,
+        "LastRec": 3,
+        "LastUpl": 2,
         "sigStrength": 26,
         "DataBalance": 67.0
     })
@@ -67,7 +73,10 @@ def test_build_valid_request():
         "connected": True,
         "longitude": 1.034,
         "latitude": 0.564,
-        "batteryLevel": 30,
+        "bV": 30,
+        "pV": 30,
+        "LastRec": 3,
+        "LastUpl": 2,
         "sigStrength": 26,
         "DataBalance": 67.0
     }

--- a/tests/use_cases/test_sensor_reading.py
+++ b/tests/use_cases/test_sensor_reading.py
@@ -34,7 +34,10 @@ def test_new_sensor_reading(sensor_repo):
         connected=True,
         longitude=1.034,
         latitude=0.564,
-        batteryLevel=30.0,
+        bV=30,
+        pV=30,
+        LastRec=3,
+        LastUpl=2,
         sigStrength=26.0,
         DataBalance=67
     )


### PR DESCRIPTION
### What does this PR do?
- Adds the following new MQTT fields:
  - `bV`: battery voltage
  - `pV`: panel voltage
  - `LastRec`: last recording made by the sensor.
  - `LastUpl`: last uploaded recording.
- Makes the `connected` field optional.