### PR TITLE
Fetch all devices and their attached locations

### DIFF
--- a/device_metrics/serializers.py
+++ b/device_metrics/serializers.py
@@ -5,7 +5,7 @@ from devices.serializers import DeviceSerializer
 
 
 class DeviceMetricsSerializer(serializers.ModelSerializer):
-    device = serializers.PrimaryKeyRelatedField(queryset=Device.objects.all())                                      
+    device = serializers.PrimaryKeyRelatedField(queryset=Device.objects.all())
 
     class Meta:
         model = DeviceMetrics

--- a/device_metrics/serializers.py
+++ b/device_metrics/serializers.py
@@ -5,8 +5,7 @@ from devices.serializers import DeviceSerializer
 
 
 class DeviceMetricsSerializer(serializers.ModelSerializer):
-    device = serializers.SlugRelatedField(queryset=Device.objects.all(),
-                                          slug_field='device_id')
+    device = serializers.PrimaryKeyRelatedField(queryset=Device.objects.all())                                      
 
     class Meta:
         model = DeviceMetrics

--- a/device_metrics/urls.py
+++ b/device_metrics/urls.py
@@ -8,6 +8,6 @@ router = SimpleRouter()
 router.register('', ReceiveDeviceMetricsViewSet)
 
 urlpatterns = [
-    path('<slug:device_id>', ListDeviceMetrics.as_view(), name='device_device_metrics'),
+    path('device/<uuid:pk>', ListDeviceMetrics.as_view(), name='device_device_metrics'),
     path('', include(router.urls))
 ]

--- a/device_metrics/views.py
+++ b/device_metrics/views.py
@@ -16,5 +16,5 @@ class ListDeviceMetrics(ListAPIView):
 
     def get_queryset(self):
         return self.queryset.filter(
-            device__device_id=self.kwargs['device_id']
+            device__id=self.kwargs['pk']
         )

--- a/devices/serializers.py
+++ b/devices/serializers.py
@@ -9,12 +9,13 @@ class DeviceSerializer(serializers.ModelSerializer):
         fields = ['device_id']
 
 
-class LocationSerializer(serializers.ModelSerializer):
+class DeviceLocationSerializer(serializers.ModelSerializer):
+    id = serializers.CharField(source='device_id')
 
     class Meta:
         model = Location
         fields = [
-            'device', 'latitude', 'longitude', 'city', 
+            'id', 'latitude', 'longitude', 'city',
             'division', 'parish', 'village'
         ]
 
@@ -23,4 +24,5 @@ class DeviceConfigSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Device
-        fields = ['configured', 'device_id', 'dbLevel', 'recLength', 'uploadAddr']
+        fields = ['configured', 'device_id',
+                  'dbLevel', 'recLength', 'uploadAddr']

--- a/devices/serializers.py
+++ b/devices/serializers.py
@@ -9,11 +9,14 @@ class DeviceSerializer(serializers.ModelSerializer):
         fields = ['device_id']
 
 
-class LocationSerializer(serializers.ModelField):
+class LocationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Location
-        fields = ['latitude', 'longitude', 'city', 'division', 'parish', 'village']
+        fields = [
+            'device', 'latitude', 'longitude', 'city', 
+            'division', 'parish', 'village'
+        ]
 
 
 class DeviceConfigSerializer(serializers.ModelSerializer):

--- a/devices/urls.py
+++ b/devices/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, include
 
 from .views import (
     DeviceListView, DeviceDetailView, DeviceCreateView, DeviceUpdateView,
-    DeviceConfigurationUpdateView, DeviceConfigurationViewSet, 
+    DeviceListAPIView, DeviceConfigurationUpdateView, DeviceConfigurationViewSet, 
     LocationCreateView, LocationUpdateView
 )
 
@@ -13,6 +13,7 @@ router.register('config', DeviceConfigurationViewSet)
 
 urlpatterns = [
     path('', DeviceListView.as_view(), name='device_list'),
+    path('list/', DeviceListAPIView.as_view(), name='list_devices'),
     path('<uuid:pk>', DeviceDetailView.as_view(), name='device_detail'),
     path('create_device/', DeviceCreateView.as_view(), name='create_device'),
     path('<uuid:pk>/edit/', DeviceUpdateView.as_view(), name='edit_device'),

--- a/devices/urls.py
+++ b/devices/urls.py
@@ -2,8 +2,8 @@ from django.urls import path, include
 
 from .views import (
     DeviceListView, DeviceDetailView, DeviceCreateView, DeviceUpdateView,
-    DeviceListAPIView, DeviceConfigurationUpdateView, DeviceConfigurationViewSet, 
-    LocationCreateView, LocationUpdateView
+    DeviceLocationListAPIView, DeviceConfigurationUpdateView, 
+    DeviceConfigurationViewSet, LocationCreateView, LocationUpdateView
 )
 
 from rest_framework.routers import SimpleRouter
@@ -13,7 +13,7 @@ router.register('config', DeviceConfigurationViewSet)
 
 urlpatterns = [
     path('', DeviceListView.as_view(), name='device_list'),
-    path('list/', DeviceListAPIView.as_view(), name='list_devices'),
+    path('locations/', DeviceLocationListAPIView.as_view(), name='device_locations'),
     path('<uuid:pk>', DeviceDetailView.as_view(), name='device_detail'),
     path('create_device/', DeviceCreateView.as_view(), name='create_device'),
     path('<uuid:pk>/edit/', DeviceUpdateView.as_view(), name='edit_device'),

--- a/devices/views.py
+++ b/devices/views.py
@@ -4,7 +4,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import ListView, DetailView
 from django.views.generic.edit import UpdateView, CreateView
 from .models import Device, Location
-from .serializers import LocationSerializer, DeviceConfigSerializer
+from .serializers import DeviceLocationSerializer, DeviceConfigSerializer
 from rest_framework import viewsets
 from rest_framework.generics import ListAPIView
 
@@ -13,7 +13,7 @@ from .forms import DeviceForm, DeviceConfigurationForm
 
 class DeviceLocationListAPIView(ListAPIView):
     queryset = Location.objects.all()
-    serializer_class = LocationSerializer
+    serializer_class = DeviceLocationSerializer
 
 
 class DeviceListView(ListView):

--- a/devices/views.py
+++ b/devices/views.py
@@ -4,22 +4,22 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import ListView, DetailView
 from django.views.generic.edit import UpdateView, CreateView
 from .models import Device, Location
-from .serializers import DeviceSerializer, DeviceConfigSerializer
+from .serializers import LocationSerializer, DeviceConfigSerializer
 from rest_framework import viewsets
 from rest_framework.generics import ListAPIView
 
 from .forms import DeviceForm, DeviceConfigurationForm
 
 
+class DeviceLocationListAPIView(ListAPIView):
+    queryset = Location.objects.all()
+    serializer_class = LocationSerializer
+
+
 class DeviceListView(ListView):
     model = Device
     context_object_name = 'device_list'
     template_name = 'devices/device_list.html'
-
-
-class DeviceListAPIView(ListAPIView):
-    queryset = Device.objects.all()
-    serializer_class = DeviceSerializer
 
 
 class DeviceDetailView(DetailView):

--- a/devices/views.py
+++ b/devices/views.py
@@ -4,8 +4,9 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import ListView, DetailView
 from django.views.generic.edit import UpdateView, CreateView
 from .models import Device, Location
-from .serializers import DeviceConfigSerializer
+from .serializers import DeviceSerializer, DeviceConfigSerializer
 from rest_framework import viewsets
+from rest_framework.generics import ListAPIView
 
 from .forms import DeviceForm, DeviceConfigurationForm
 
@@ -14,6 +15,11 @@ class DeviceListView(ListView):
     model = Device
     context_object_name = 'device_list'
     template_name = 'devices/device_list.html'
+
+
+class DeviceListAPIView(ListAPIView):
+    queryset = Device.objects.all()
+    serializer_class = DeviceSerializer
 
 
 class DeviceDetailView(DetailView):


### PR DESCRIPTION
This PR adds an API endpoint for fetching all devices with their attached locations

**How to test this PR**
* Pull this branch
* Run the app: `docker-compose -f docker-compose-web.yml up`
* In Postman, test the following endpoint: `GET http://localhost:8000/devices/locations`
* It will return the response in this format:
```
[
    {
        "id": "49e879b0-f41a-4524-b383-1ab6f7354ab1",
        "latitude": 0.3476,
        "longitude": 32.5825,
        "city": "Kampala",
        "division": "N/A",
        "parish": "N/A",
        "village": "N/A"
    },
    {
        "id": "f24113bc-6352-45f8-a0da-e0572abece39",
        "latitude": 0.0512,
        "longitude": 32.4637,
        "city": "Entebbe",
        "division": "A",
        "parish": "N/A",
        "village": "Katabi"
    }
]
```

**NOTE:**
The endpoint for fetching device metrics for a particular device has changed from `http://localhost:8000/device_metrics/<uuid>` to `http://localhost:8000/device_metrics/device/<uuid>` 