### PR TITLE
Send metrics to API Endpoints

### DIFF
--- a/device_metrics/serializers.py
+++ b/device_metrics/serializers.py
@@ -1,11 +1,12 @@
 from rest_framework import serializers
 from .models import DeviceMetrics
 from devices.models import Device
-from devices.serializers import DeviceSerializer
 
 
 class DeviceMetricsSerializer(serializers.ModelSerializer):
-    device = serializers.PrimaryKeyRelatedField(queryset=Device.objects.all())
+    # device = serializers.PrimaryKeyRelatedField(queryset=Device.objects.all())
+    device = serializers.SlugRelatedField(queryset=Device.objects.all(),
+                                          slug_field='device_id')
 
     class Meta:
         model = DeviceMetrics

--- a/mqtt/subscribe.py
+++ b/mqtt/subscribe.py
@@ -11,6 +11,7 @@ from noise_sensors_monitoring.requests.sensor_reading import build_sensor_readin
 
 from noise_sensors_monitoring.requests.device_config import build_device_config_request
 from noise_sensors_monitoring.repository.devices_repo import DevicesRepo
+from noise_sensors_monitoring.repository.in_memory_repo import InMemoryRepo
 from noise_sensors_monitoring.use_cases.devices_config import get_device_config
 
 from mqtt.publish import publish_device_configuration
@@ -24,6 +25,7 @@ repo = InfluxDBRepo({
     "influx_bucket": os.environ["INFLUX_BUCKET"]
 })
 devices_repo = DevicesRepo()
+in_memory_repo = InMemoryRepo()
 
 
 def on_message(_, __, message):
@@ -36,7 +38,7 @@ def on_message(_, __, message):
         return
     if topic == 'sb/sensor/logs':
         request = build_sensor_reading_request(message_content)
-        response = add_new_sensor_reading(request, repo)
+        response = add_new_sensor_reading(request, repo, in_memory_repo)
         print(response.value)  # TODO: Use logs for this
     elif topic == 'sb/sensor/configs':
         request = build_device_config_request(message_content)

--- a/noise_sensors_monitoring/domain/sensor.py
+++ b/noise_sensors_monitoring/domain/sensor.py
@@ -28,6 +28,9 @@ class Sensor:
 class AggregateSensorMetric:
     device: str
     db_level: int
+    avg_db_level: int
+    max_db_level: int
+    no_of_exceedances: int
     # minDbLevel: float TODO: Add these later, when they're implemented in the API
     # maxDbLevel: float
     sig_strength: int

--- a/noise_sensors_monitoring/domain/sensor.py
+++ b/noise_sensors_monitoring/domain/sensor.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, asdict
 from typing import Dict
 
+
 @dataclass
 class Sensor:
     deviceId: str
@@ -18,6 +19,27 @@ class Sensor:
     @classmethod
     def from_dict(cls, data: Dict):
         return cls(**data)
-    
+
+    def to_dict(self):
+        return asdict(self)
+
+
+@dataclass
+class AggregateSensorMetric:
+    device: str
+    db_level: int
+    # minDbLevel: float TODO: Add these later, when they're implemented in the API
+    # maxDbLevel: float
+    sig_strength: int
+    last_rec: int
+    last_upl: int
+    panel_voltage: int
+    battery_voltage: int
+    data_balance: int
+
+    @classmethod
+    def from_dict(cls, data: Dict):
+        return cls(**data)
+
     def to_dict(self):
         return asdict(self)

--- a/noise_sensors_monitoring/repository/in_memory_repo.py
+++ b/noise_sensors_monitoring/repository/in_memory_repo.py
@@ -22,28 +22,42 @@ class InMemoryRepo(SensorReadingRepo):
             self.metrics[sensor.deviceId] = []
 
         self.metrics[sensor.deviceId].append(sensor)
+        self.send_data_to_api(sensor.deviceId)
 
     def send_data_to_api(self, device_id: str):
         # check if there is enough data (i.e ==60 records)
-        # if there is, then calculate the average db level, max db level, min db level,
-        # and the latest values for the rest of the metrics
+        if len(self.metrics[device_id]) < 60:
+            return
+        # calculate the average db level, max db level
+        aggregate_metric = self.calculate_aggregate_stats(device_id)
+
         # send data to api
+        self.send_data(aggregate_metric)
+
         # reset metrics for device to empty list
-        pass
+        self.metrics[device_id] = []
 
     def calculate_aggregate_stats(self, device_id: str) -> AggregateSensorMetric:
         sensor_metrics = self.metrics[device_id]
 
         # calculate average DB level
         db_avg = 0
+        max_db_level = 0
+        exceedances = 0
         for sensor in sensor_metrics:
             db_avg += sensor.dbLevel
+            max_db_level = max(max_db_level, sensor.dbLevel)
+            if sensor.dbLevel >= 70:
+                exceedances += 1
 
         db_avg //= len(sensor_metrics)
         last_sensor = sensor_metrics[-1]
         return AggregateSensorMetric.from_dict({
             "device": device_id,
-            "db_level": db_avg,
+            "db_level": last_sensor.dbLevel,
+            "avg_db_level": db_avg,
+            "max_db_level": max_db_level,
+            "no_of_exceedances": exceedances,
             "sig_strength": last_sensor.sigStrength,
             "last_rec": last_sensor.LastRec,
             "last_upl": last_sensor.LastUpl,
@@ -52,8 +66,14 @@ class InMemoryRepo(SensorReadingRepo):
             "data_balance": last_sensor.DataBalance
         })
 
-    def send_data(self):
-        pass
+    @staticmethod
+    def send_data(aggregate_metric: AggregateSensorMetric):
+        url = f"{BASE_URL}/device_metrics/"
+        payload = json.dumps(aggregate_metric.to_dict())
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        requests.request("POST", url, headers=headers, data=payload)
 
     def get_latest_sensor_reading(self) -> Sensor:
         pass

--- a/noise_sensors_monitoring/repository/in_memory_repo.py
+++ b/noise_sensors_monitoring/repository/in_memory_repo.py
@@ -1,0 +1,59 @@
+import os
+import json
+import requests
+from dotenv import load_dotenv
+
+from noise_sensors_monitoring.domain.sensor import Sensor, AggregateSensorMetric
+from noise_sensors_monitoring.repository.time_series_repo_interface import SensorReadingRepo
+from typing import Dict, List
+
+load_dotenv()
+BASE_URL = os.getenv('HTTP_APP_HOST')
+
+
+class InMemoryRepo(SensorReadingRepo):
+
+    def __init__(self):
+        self.metrics: Dict[str, List[Sensor]] = {}
+
+    def add_new_sensor_reading(self, sensor_reading: Dict):
+        sensor = Sensor.from_dict(sensor_reading)
+        if sensor.deviceId not in self.metrics:
+            self.metrics[sensor.deviceId] = []
+
+        self.metrics[sensor.deviceId].append(sensor)
+
+    def send_data_to_api(self, device_id: str):
+        # check if there is enough data (i.e ==60 records)
+        # if there is, then calculate the average db level, max db level, min db level,
+        # and the latest values for the rest of the metrics
+        # send data to api
+        # reset metrics for device to empty list
+        pass
+
+    def calculate_aggregate_stats(self, device_id: str) -> AggregateSensorMetric:
+        sensor_metrics = self.metrics[device_id]
+
+        # calculate average DB level
+        db_avg = 0
+        for sensor in sensor_metrics:
+            db_avg += sensor.dbLevel
+
+        db_avg //= len(sensor_metrics)
+        last_sensor = sensor_metrics[-1]
+        return AggregateSensorMetric.from_dict({
+            "device": device_id,
+            "db_level": db_avg,
+            "sig_strength": last_sensor.sigStrength,
+            "last_rec": last_sensor.LastRec,
+            "last_upl": last_sensor.LastUpl,
+            "panel_voltage": last_sensor.pV,
+            "battery_voltage": last_sensor.bV,
+            "data_balance": last_sensor.DataBalance
+        })
+
+    def send_data(self):
+        pass
+
+    def get_latest_sensor_reading(self) -> Sensor:
+        pass

--- a/noise_sensors_monitoring/use_cases/sensor_reading.py
+++ b/noise_sensors_monitoring/use_cases/sensor_reading.py
@@ -7,11 +7,12 @@ from noise_sensors_monitoring.responses import (
 )
 
 
-def add_new_sensor_reading(request: Request, repo: SensorReadingRepo):
+def add_new_sensor_reading(request: Request, repo: SensorReadingRepo, in_memory_repo: SensorReadingRepo):
     if not request:
         return build_response_from_invalid_request(request)
     try:
         repo.add_new_sensor_reading(request.request_dict)
+        in_memory_repo.add_new_sensor_reading(request.request_dict)
         return ResponseSuccess("Successfully added the new sensor reading")
     except Exception as exc:
         return ResponseFailure(ResponseTypes.SYSTEM_ERROR, exc)

--- a/tests/use_cases/test_sensor_reading.py
+++ b/tests/use_cases/test_sensor_reading.py
@@ -44,7 +44,7 @@ def test_new_sensor_reading(sensor_repo):
 
     request = build_sensor_reading_request(sensor_reading.to_dict())
 
-    response = add_new_sensor_reading(request, repo)
+    response = add_new_sensor_reading(request, repo, repo)
 
     latest_sensor = get_latest_sensor_reading(repo)
 


### PR DESCRIPTION
This PR implements functionality to send metrics from the Sensors to the API endpoints, so that metric data is available for analysis.

### How to test:
- Run the project: `docker-compose up -d`
- Paste the following code in a test file, e.g `try_broker_publish.py`:
```
import json
import time
import random

import paho.mqtt.client as mqtt
mqttBroker = "localhost"
client = mqtt.Client("Test")
client.connect(mqttBroker)

imei_test = "143251545435435"


def test_device_logs():
    while True:
        sensor = random.randint(1, 1)
        message = {
            "deviceId": f'SB100{sensor}',
            "dbLevel": random.randint(60, 121),
            "longitude": 1.034,
            "latitude": 0.564,
            "bV": random.randint(10, 100),
            "pV": random.randint(10, 100),
            "LastRec": random.randint(0, 2000),
            "LastUpl": random.randint(0, 2000),
            "sigStrength": random.randint(0, 31),
            "DataBalance": 78
        }
        info = client.publish("sb/sensor/logs", json.dumps(message))
        print(f"Was message sent?: {info.is_published()}")
        print("Published message")
        time.sleep(2)

test_device_logs()
```
- Run `python try_broker_publish.py`.
- Check if metrics are being sent by going to the metrics endpoint of a device: `http://localhost:8000/device_metrics/device/<uuid>`

**NOTE**: For faster testing, go to the file `noise_sensors_monitoring/repository/in_memory_repo.py` and change the `60` on line 29 to a smaller value e.g `2`.