### PR TITLE
Add CSV export functionality for environmental parameters

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build the project
-        run: docker-compose -f docker-compose-test.yml up -d --build
+        run: docker compose -f docker-compose-test.yml up -d --build
       - name: Run Django and pytest tests and generate report
         run: |
           docker compose exec -T web coverage run --source=noise_sensors_monitoring,mqtt -m pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,12 +17,12 @@ jobs:
         run: docker-compose -f docker-compose-test.yml up -d --build
       - name: Run Django and pytest tests and generate report
         run: |
-          docker-compose exec -T web coverage run --source=noise_sensors_monitoring,mqtt -m pytest
-          docker-compose exec -T web coverage run -a --source=users,pages,devices manage.py test
-          docker-compose exec -T web coverage report -m
+          docker compose exec -T web coverage run --source=noise_sensors_monitoring,mqtt -m pytest
+          docker compose exec -T web coverage run -a --source=users,pages,devices manage.py test
+          docker compose exec -T web coverage report -m
       - name: Upload Coverage to Codecov
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
-          docker-compose exec -T web pip install codecov
-          docker-compose exec -T web codecov -t $CODECOV_TOKEN
+          docker compose exec -T web pip install codecov
+          docker compose exec -T web codecov -t $CODECOV_TOKEN

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,14 @@ WORKDIR /code
 # Upgrade Pip
 # RUN pip install --upgrade pip
 
+# install a modern libpq and build deps for psycopg2
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      libpq-dev     \
+      gcc           \
+ && rm -rf /var/lib/apt/lists/*
+
+
 # Install dependencies
 COPY requirements.txt /code/
 RUN pip install -r requirements.txt

--- a/device_metrics/tests.py
+++ b/device_metrics/tests.py
@@ -87,7 +87,7 @@ class EnvironmentalParameterExportCsvTest(TestCase):
                 power_usage=5.0 + i,
             )
         self.client = APIClient()
-        self.url = reverse("environmentalparameter-export-csv-list")
+        self.url = reverse("environmentalparameter-export-csv")
 
     def test_export_csv_default(self):
         response = self.client.get(self.url)

--- a/device_metrics/tests.py
+++ b/device_metrics/tests.py
@@ -1,4 +1,6 @@
 from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
 
 from devices.models import Device
 
@@ -68,3 +70,59 @@ class SoundInferenceDataModelTest(TestCase):
         self.assertEqual(
             str(SoundInferenceData._meta.verbose_name_plural), "Sound Inference Data"
         )
+
+
+class EnvironmentalParameterExportCsvTest(TestCase):
+    def setUp(self):
+        self.device = Device.objects.create(device_id="device_001")
+        for i in range(30):
+            EnvironmentalParameter.objects.create(
+                device=self.device,
+                temperature=20.0 + i,
+                pressure=1000.0 + i,
+                humidity=40.0 + i,
+                air_quality=1.0 + i,
+                ram_value=256.0 + i,
+                system_temperature=45.0 + i,
+                power_usage=5.0 + i,
+            )
+        self.client = APIClient()
+        self.url = reverse("environmentalparameter-export-csv-list")
+
+    def test_export_csv_default(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        content = response.content.decode()
+        self.assertIn(
+            "id,device,temperature,pressure,humidity,air_quality,ram_value,system_temperature,power_usage,created_at",
+            content,
+        )
+        self.assertTrue(len(content.splitlines()) > 1)  # header + data
+
+    def test_export_csv_all(self):
+        response = self.client.get(self.url, {"all": "true"})
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # 30 rows + 1 header
+        self.assertEqual(len(content.splitlines()), 31)
+
+    def test_export_csv_count(self):
+        response = self.client.get(self.url, {"count": 5})
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertEqual(len(content.splitlines()), 6)  # 5 rows + 1 header
+
+    def test_export_csv_page(self):
+        response = self.client.get(self.url, {"page": 2, "page_size": 10})
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertEqual(len(content.splitlines()), 11)  # 10 rows + 1 header
+
+    def test_export_csv_page_range(self):
+        response = self.client.get(
+            self.url, {"start_page": 2, "end_page": 3, "page_size": 5}
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertEqual(len(content.splitlines()), 11)  # (pages 2 and 3 = 10 rows) + 1 header

--- a/device_metrics/views.py
+++ b/device_metrics/views.py
@@ -1,5 +1,10 @@
 from rest_framework import viewsets
 from rest_framework.generics import ListAPIView
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from django.http import HttpResponse
+import csv
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
 
 from .models import DeviceMetrics, EnvironmentalParameter, SoundInferenceData
 from .serializers import (
@@ -25,6 +30,74 @@ class ListDeviceMetrics(ListAPIView):
 class EnvironmentalParameterViewSet(viewsets.ModelViewSet):
     queryset = EnvironmentalParameter.objects.all().order_by("-created_at")
     serializer_class = EnvironmentalParameterSerializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name="all", type=OpenApiTypes.BOOL, location=OpenApiParameter.QUERY, description="Export all items"),
+            OpenApiParameter(name="count", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="Number of items to export"),
+            OpenApiParameter(name="page", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="Page number to export"),
+            OpenApiParameter(name="start_page", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="Start page for range export"),
+            OpenApiParameter(name="end_page", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="End page for range export"),
+            OpenApiParameter(name="page_size", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="Page size (default 25)"),
+        ],
+        responses={200: {'content': {'text/csv': {}}}, 'description': 'CSV file download'},
+        description="Export environmental parameters to CSV with flexible filtering options."
+    )
+    @action(detail=False, methods=["get"], url_path="export-csv")
+    def export_csv(self, request):
+        # Query params
+        export_all = request.query_params.get("all", "false").lower() == "true"
+        count = request.query_params.get("count")
+        page = request.query_params.get("page")
+        start_page = request.query_params.get("start_page")
+        end_page = request.query_params.get("end_page")
+        page_size = int(request.query_params.get("page_size", 25))
+
+        queryset = self.get_queryset()
+
+        # Pagination logic
+        if export_all:
+            data = queryset
+        elif count:
+            data = queryset[:int(count)]
+        elif page:
+            page = int(page)
+            start = (page - 1) * page_size
+            end = start + page_size
+            data = queryset[start:end]
+        elif start_page and end_page:
+            start_page = int(start_page)
+            end_page = int(end_page)
+            start = (start_page - 1) * page_size
+            end = end_page * page_size
+            data = queryset[start:end]
+        else:
+            # Default: first page
+            data = queryset[:page_size]
+
+        # Prepare CSV
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="environmental_parameters.csv"'
+        writer = csv.writer(response)
+        # Write header
+        writer.writerow([
+            "id", "device", "temperature", "pressure", "humidity", "air_quality", "ram_value", "system_temperature", "power_usage", "created_at"
+        ])
+        # Write data
+        for obj in data:
+            writer.writerow([
+                obj.id,
+                getattr(obj.device, 'device_id', obj.device),
+                obj.temperature,
+                obj.pressure,
+                obj.humidity,
+                obj.air_quality,
+                obj.ram_value,
+                obj.system_temperature,
+                obj.power_usage,
+                obj.created_at,
+            ])
+        return response
 
 
 class SoundInferenceDataViewSet(viewsets.ModelViewSet):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: "redis:7.0.11-alpine"
 
   postgres_db:
-    image: postgres
+    image: postgres:12-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
This pull request introduces several updates to improve functionality and compatibility, including enhancements to the `EnvironmentalParameterViewSet` for exporting data, updates to the Docker environment, and dependency changes. Below is a summary of the most important changes:

### Enhancements to `EnvironmentalParameterViewSet`:

* Added an `export_csv` endpoint to `EnvironmentalParameterViewSet` for exporting environmental parameters as a CSV file. The endpoint supports flexible filtering options such as exporting all data, limiting by count, or paginating via query parameters. (`device_metrics/views.py`, [device_metrics/views.pyR34-R101](diffhunk://#diff-478e34528bbbed1e6d65990f36958e50771ab764f0874c354abbd694a799d33fR34-R101))
* Introduced schema documentation for the `export_csv` endpoint using `drf-spectacular` to provide OpenAPI parameter definitions and response descriptions. (`device_metrics/views.py`, [device_metrics/views.pyR34-R101](diffhunk://#diff-478e34528bbbed1e6d65990f36958e50771ab764f0874c354abbd694a799d33fR34-R101))

### Updates to the Docker environment:

* Updated the `postgres_db` service in `docker-compose.yml` to use the `postgres:12-alpine` image for better compatibility and reduced image size. (`docker-compose.yml`, [docker-compose.ymlL9-R9](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L9-R9))
* Added installation steps in the `Dockerfile` to include `libpq-dev` and `gcc` as build dependencies for `psycopg2`, ensuring compatibility with modern PostgreSQL libraries. (`Dockerfile`, [DockerfileR18-R25](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R18-R25))