### PR TITLE
Add year filtering to CSV export for environmental parameters

### DIFF
--- a/device_metrics/tests.py
+++ b/device_metrics/tests.py
@@ -130,9 +130,9 @@ class EnvironmentalParameterExportCsvTest(TestCase):
     def test_export_csv_year(self):
         # Create records for a different year
         from datetime import datetime
-        import pytz
-        tz = pytz.UTC
-        EnvironmentalParameter.objects.create(
+        from django.utils import timezone
+
+        param = EnvironmentalParameter.objects.create(
             device=self.device,
             temperature=99.0,
             pressure=999.0,
@@ -141,11 +141,13 @@ class EnvironmentalParameterExportCsvTest(TestCase):
             ram_value=999.0,
             system_temperature=99.0,
             power_usage=9.0,
-            created_at=tz.localize(datetime(2020, 5, 1, 12, 0, 0)),
         )
+        # Set created_at to 2020
+        param.created_at = timezone.make_aware(datetime(2020, 5, 1, 12, 0, 0))
+        param.save()
+
         # Get only current year records
-        from datetime import datetime
-        current_year = datetime.now().year
+        current_year = timezone.now().year
         response = self.client.get(self.url, {"year": current_year})
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()

--- a/device_metrics/tests.py
+++ b/device_metrics/tests.py
@@ -126,3 +126,38 @@ class EnvironmentalParameterExportCsvTest(TestCase):
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
         self.assertEqual(len(content.splitlines()), 11)  # (pages 2 and 3 = 10 rows) + 1 header
+
+    def test_export_csv_year(self):
+        # Create records for a different year
+        from datetime import datetime
+        import pytz
+        tz = pytz.UTC
+        EnvironmentalParameter.objects.create(
+            device=self.device,
+            temperature=99.0,
+            pressure=999.0,
+            humidity=99.0,
+            air_quality=9.0,
+            ram_value=999.0,
+            system_temperature=99.0,
+            power_usage=9.0,
+            created_at=tz.localize(datetime(2020, 5, 1, 12, 0, 0)),
+        )
+        # Get only current year records
+        from datetime import datetime
+        current_year = datetime.now().year
+        response = self.client.get(self.url, {"year": current_year})
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # Should not include the 2020 record
+        self.assertNotIn(
+            "99.0,999.0,99.0,9.0,999.0,99.0,9.0", content
+        )
+        # Should include at least one of the current year records
+        self.assertIn(str(current_year), content)
+
+        # Get only 2020 records
+        response = self.client.get(self.url, {"year": 2020})
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("99.0,999.0,99.0,9.0,999.0,99.0,9.0", content)

--- a/device_metrics/views.py
+++ b/device_metrics/views.py
@@ -39,6 +39,7 @@ class EnvironmentalParameterViewSet(viewsets.ModelViewSet):
             OpenApiParameter(name="start_page", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="Start page for range export"),
             OpenApiParameter(name="end_page", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="End page for range export"),
             OpenApiParameter(name="page_size", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="Page size (default 25)"),
+            OpenApiParameter(name="year", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, description="Year to filter records by (created_at year)"),
         ],
         responses={200: {'content': {'text/csv': {}}}, 'description': 'CSV file download'},
         description="Export environmental parameters to CSV with flexible filtering options."
@@ -52,8 +53,11 @@ class EnvironmentalParameterViewSet(viewsets.ModelViewSet):
         start_page = request.query_params.get("start_page")
         end_page = request.query_params.get("end_page")
         page_size = int(request.query_params.get("page_size", 25))
+        year = request.query_params.get("year")
 
         queryset = self.get_queryset()
+        if year:
+            queryset = queryset.filter(created_at__year=year)
 
         # Pagination logic
         if export_all:


### PR DESCRIPTION
This pull request introduces a feature to filter environmental parameter records by year when exporting to CSV, along with corresponding tests and API documentation updates. The changes ensure that users can specify a year to retrieve only the records created in that year.

### Feature: Year-based filtering for CSV export

* **Added a `year` query parameter to API documentation**: Updated the `OpenApiParameter` list in `EnvironmentalParameterViewSet` to include a new `year` parameter for filtering records by their `created_at` year. (`device_metrics/views.py`, [device_metrics/views.pyR42](diffhunk://#diff-478e34528bbbed1e6d65990f36958e50771ab764f0874c354abbd694a799d33fR42))
* **Implemented year filtering in the `export_csv` method**: Modified the `export_csv` method to filter the queryset by the `created_at` year if the `year` parameter is provided in the request. (`device_metrics/views.py`, [device_metrics/views.pyR56-R60](diffhunk://#diff-478e34528bbbed1e6d65990f36958e50771ab764f0874c354abbd694a799d33fR56-R60))

### Tests: Validation of year filtering functionality

* **Added a new test case `test_export_csv_year`**: This test ensures that the CSV export correctly filters records based on the specified year, verifying both inclusion and exclusion of records as appropriate. (`device_metrics/tests.py`, [device_metrics/tests.pyR129-R163](diffhunk://#diff-48ebb649595784872cf4736ee4ca72ce54fd66ef2e63530aa7042cf531d2bbe0R129-R163))